### PR TITLE
Add proper StageGroup and StackGroup objects

### DIFF
--- a/kitipy/__init__.py
+++ b/kitipy/__init__.py
@@ -1,5 +1,6 @@
 from .dispatcher import Dispatcher
 from .context import Context, pass_context, get_current_context, get_current_executor
+from .exceptions import TaskError
 from .executor import Executor, InteractiveWarningPolicy
 from .groups import Task, Group, RootCommand, StackGroup, StageGroup, root, task, group
 from .utils import append_cmd_flags, load_config_file, normalize_config, set_up_file_transfer_listeners, wait_for
@@ -16,6 +17,9 @@ __all__ = [
     'pass_context',
     'get_current_context',
     'get_current_executor',
+
+    # from exceptions module
+    'TaskError',
 
     # from executor module
     'Executor',
@@ -39,7 +43,6 @@ __all__ = [
     # action modules
     'ansible_actions',
     'git_actions',
-    'sphinx_actions',
 
     # other modules
     'filters',

--- a/kitipy/__init__.py
+++ b/kitipy/__init__.py
@@ -1,7 +1,7 @@
 from .dispatcher import Dispatcher
 from .context import Context, pass_context, get_current_context, get_current_executor
 from .executor import Executor, InteractiveWarningPolicy
-from .groups import Task, Group, RootCommand, root, task, group
+from .groups import Task, Group, RootCommand, StackGroup, StageGroup, root, task, group
 from .utils import append_cmd_flags, load_config_file, normalize_config, set_up_file_transfer_listeners, wait_for
 from . import docker, filters
 

--- a/kitipy/context.py
+++ b/kitipy/context.py
@@ -213,9 +213,14 @@ class Context(object):
 pass_context = click.make_pass_decorator(Context)
 
 
-def get_current_context() -> Context:
+def get_current_context(click_ctx: Optional[click.Context] = None) -> Context:
     """
     Find the current kitipy context or raise an error.
+
+    Args:
+        click_ctx (click.Context):
+            The click.Context where this function should look for a
+            kitipy.Context.
 
     Raises:
         RuntimeError: When no kitipy context has been found.
@@ -224,7 +229,9 @@ def get_current_context() -> Context:
         Context: The current kitipy context.
     """
 
-    click_ctx = click.get_current_context()
+    if click_ctx is None:
+        click_ctx = click.get_current_context()
+
     kctx = click_ctx.find_object(Context)
     if kctx is None:
         raise RuntimeError('No kitipy context found.')

--- a/kitipy/exceptions.py
+++ b/kitipy/exceptions.py
@@ -1,0 +1,19 @@
+import click
+from typing import Optional
+
+
+class TaskError(click.ClickException):
+    def __init__(self,
+                 message: str,
+                 click_ctx: Optional[click.Context] = None,
+                 exit_code: int = 1):
+        super().__init__(message)
+        self.exit_code = exit_code
+        self.click_ctx = click_ctx
+
+    def show(self, file=None):
+        color = self.click_ctx.color if self.click_ctx else None
+        msg = click.style('Error: %s' % self.format_message(),
+                          fg='bright_white',
+                          bg='red')
+        click.echo(msg, file=file, color=color)

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -101,6 +101,7 @@ class Group(click.Group):
                  filters: List[Callable[[click.Context], bool]] = [],
                  cwd: Optional[str] = None,
                  invoke_on_help: bool = False,
+                 transparents: List[click.MultiCommand] = [],
                  **attrs):
         """
         Args:
@@ -129,6 +130,9 @@ class Group(click.Group):
         self.filters = filters
         self.cwd = cwd
         self.invoke_on_help = invoke_on_help
+
+        for group in transparents:
+            self.add_transparent_group(group)
 
     @property
     def transparent_groups(self) -> List[click.MultiCommand]:

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -2,19 +2,12 @@ import click
 import functools
 import os
 import subprocess
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from . import filters
 from .context import Context, pass_context, get_current_context, get_current_executor
 from .dispatcher import Dispatcher
 from .executor import Executor, _create_executor
 from .utils import load_config_file, normalize_config, set_up_file_transfer_listeners
-
-
-def _fake_click_ctx() -> click.Context:
-    """This internal function is used to create a fake click Context. It's 
-    used by Group.merge() to list Tasks from source Groups.
-    """
-    return click.Context.__new__(click.Context)
 
 
 class Task(click.Command):
@@ -77,7 +70,7 @@ class Task(click.Command):
         for filter in self.filters:
             if not filter(click_ctx):
                 return False
-        return True
+        return self.hidden != True
 
     def invoke(self, click_ctx: click.Context):
         """Given a context, this invokes the attached callback (if it exists)
@@ -95,35 +88,8 @@ class Task(click.Command):
 
         return super().invoke(click_ctx)
 
-    def get_help_option(self, click_ctx: click.Context):
-        """This is a click.Command method overriden to implement task
-        filtering.
-        """
-        help_options = self.get_help_option_names(click_ctx)
-        if not help_options or not self.add_help_option:
-            return
 
-        def show_help(click_ctx, param, value):
-            """Returns the help option object when the task is not
-            filtered out, or raise an Error.
-            """
-            if not self.is_enabled(click_ctx):
-                click_ctx.fail('Task "%s" not found.' % self.name)
-
-            if value and not click_ctx.resilient_parsing:
-                click.echo(click_ctx.get_help(), color=click_ctx.color)
-                click_ctx.exit()
-
-        return click.Option(  # type: ignore
-            help_options,
-            is_flag=True,
-            is_eager=True,
-            expose_value=False,
-            callback=show_help,
-            help='Show this message and exit.')
-
-
-class Group(click.Group, Task):
+class Group(click.Group):
     """Group is like regular click.Group but it implements some ktipy-specific
     features like: support for stage/stack-scoped task groups and task
     filtering.
@@ -157,11 +123,36 @@ class Group(click.Group, Task):
                 Any other constructor parameters accepted by click.Group.
         """
         super().__init__(name, commands, **attrs)
-        self._stage_group = None
-        self._stack_group = None
+        self._transparents = {}  # type: Dict[str, click.MultiCommand]
+        self._resolved = {}  # type: Dict[str, click.Command]
         self.filters = filters
         self.cwd = cwd
         self.invoke_on_help = invoke_on_help
+
+    @property
+    def transparent_groups(self) -> List[click.MultiCommand]:
+        return list(self._transparents.values())
+
+    def add_command(self, cmd, name=None):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't merge or add new tasks or commands at this point."
+            )
+
+        super().add_command(cmd, name)
+
+    def add_transparent_group(self, group: click.MultiCommand):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't add new transparent groups at this point."
+            )
+
+        if group.name in self._transparents:
+            raise KeyError(
+                "There's already a transparent group named %s attached to %s."
+                % (group.name, self.name))
+
+        self._transparents[group.name] = group
 
     def merge(self, *args: click.Group):
         """This method can be used to merge click.Group(s), including kitipy
@@ -173,11 +164,92 @@ class Group(click.Group, Task):
                 One or many source click.Groups you want to merge in the
                 current Group.
         """
-        click_ctx = _fake_click_ctx()
         for src in args:
-            for cmdname in src.list_commands(click_ctx):
-                cmd = src.get_command(click_ctx, cmdname)
-                self.add_command(cmd)  # type: ignore
+            for cmd in src.commands.values():
+                self.add_command(cmd)
+
+            if isinstance(src, Group):
+                for group in src.transparent_groups:
+                    self.add_transparent_group(group)
+
+    def is_enabled(self, click_ctx: click.Context) -> bool:
+        """Check if the that Task should be filtered out based on click Context.
+        Most generally, you shouldn't have to worry about this method, it's 
+        automatically called by kitipy Group.
+
+        Args:
+            click_ctx (click.Context):
+                The click Context passed to the underlying filter.
+        
+        Returns:
+            bool: Either this task should be filtered in (True) or
+            filtered out (False).
+        """
+        for filter in self.filters:
+            if not filter(click_ctx):
+                return False
+        return self.hidden != True
+
+    def _resolve_commands(self, click_ctx: click.Context):
+        if len(self._resolved) > 0:
+            return self._resolved
+
+        commands = self._filter_command_list(click_ctx, self)
+        if len(commands) > 0:
+            names, origs, cmds = zip(*commands)
+        else:
+            names, origs, cmds = ((), (), ())
+
+        origins = dict(zip(names,
+                           origs))  # type: Dict[str, click.MultiCommand]
+        resolved = dict(zip(names, cmds))  # type: Dict[str, click.Command]
+
+        for group_name, group in self._transparents.items():
+            subcommands = self._filter_command_list(click_ctx, group)
+
+            if len(subcommands) > 0:
+                sub_names, sub_origs, sub_cmds = zip(*subcommands)
+            else:
+                sub_names, sub_origs, sub_cmds = ((), (), ())
+
+            colliding = list(set(origins.keys()) & set(sub_names))
+            if len(colliding) > 0:
+                colliding_errors = [
+                    '"%s" from "%s"' % (name, resolved[name])
+                    for name in colliding
+                ]
+                error = ', '.join(colliding_errors)
+
+                raise RuntimeError(
+                    'The transparent group "%s" adds command(s) colliding with: %s.'
+                    % (group.name, error))
+
+            resolved.update(dict(zip(sub_names, sub_cmds)))
+            origins.update(dict(zip(sub_names, sub_origs)))
+
+        self._resolved = resolved
+        return self._resolved
+
+    def _filter_command_list(
+            self, click_ctx: click.Context, group: click.MultiCommand
+    ) -> List[Tuple[str, click.MultiCommand, click.Command]]:
+        group = super() if group is self else group  # type: ignore
+        commands = group.list_commands(click_ctx)
+        filtered = [
+        ]  # type: List[Tuple[str, click.MultiCommand, click.Command]]
+
+        for cmd_name in commands:
+            cmd = group.get_command(click_ctx, cmd_name)
+            if cmd is None:
+                continue
+
+            if isinstance(cmd, Task) or isinstance(cmd, Group):
+                if cmd.is_enabled(click_ctx):
+                    filtered.append((cmd_name, group, cmd))
+            elif not cmd.hidden:
+                filtered.append((cmd_name, group, cmd))
+
+        return filtered
 
     def get_command(self, click_ctx: click.Context, cmd_name: str):
         """This is a click.Group method overriden to implement
@@ -187,22 +259,12 @@ class Group(click.Group, Task):
         method calls it to display the help message.
 
         You generally don't need to call it by yourself.
-
-        Raises:
-            KeyError: When the task is not found.
         """
-        kctx = click_ctx.find_object(Context)
+        resolved = self._resolve_commands(click_ctx)
+        if cmd_name not in resolved:
+            return None
 
-        if cmd_name in kctx.get_stage_names():
-            kctx.meta['stage'] = cmd_name
-            return self._stage_group
-        if cmd_name in kctx.get_stack_names():
-            kctx.meta['stack'] = cmd_name
-            return self._stack_group
-
-        cmd = super().get_command(kctx, cmd_name)
-
-        return cmd
+        return resolved[cmd_name]
 
     def list_commands(self, click_ctx: click.Context):
         """This is a click.Group method overriden to implement
@@ -210,39 +272,48 @@ class Group(click.Group, Task):
 
         You generally don't need to call it by yourself.
         """
-        commands = self.commands
-        root = click_ctx.find_root().command
-
-        kctx = get_current_context()
-        stage_names = kctx.get_stage_names()
-        if len(stage_names) > 0 and self._stage_group is not None:
-            stage_vals = (self._stage_group for i in range(len(stage_names)))
-            stage_tasks = dict(zip(stage_names, stage_vals))
-
-            commands = dict(commands, **stage_tasks)
-
-        stack_names = kctx.get_stack_names()
-        if len(stack_names) > 0 and self._stack_group is not None:
-            stack_vals = (self._stack_group for i in range(len(stack_names)))
-            stack_tasks = dict(zip(stack_names, stack_vals))
-
-            commands = dict(commands, **stack_tasks)
-
-        filtered = {}  # type: Dict[str, click.Command]
-        for cmd_name, cmd in commands.items():
-            if isinstance(cmd, Task) or isinstance(cmd, Group):
-                if cmd.is_enabled(click_ctx):
-                    filtered[cmd_name] = cmd
-            else:
-                filtered[cmd_name] = cmd
-
-        return sorted(filtered)
+        commands = self._resolve_commands(click_ctx).keys()
+        return sorted(commands)
 
     def get_help(self, click_ctx: click.Context):
         if self.invoke_on_help:
             self.invoke_without_command = True
             self.invoke(click_ctx)
         return super().get_help(click_ctx)
+
+    def format_commands(self, click_ctx: click.Context, formatter):
+        """Format Commands section for the help message."""
+        for group_name, group in self._transparents.items():
+            subcommands = group.list_commands(click_ctx)
+            self._print_group_help_section(click_ctx, group_name, group,
+                                           subcommands, formatter)
+
+        subcommands = super().list_commands(click_ctx)
+        self._print_group_help_section(click_ctx, 'Commands', self,
+                                       subcommands, formatter)
+
+    def _print_group_help_section(self, click_ctx: click.Context,
+                                  section_name: str, group, subcommands,
+                                  formatter):
+        # This code comes from click.MultiCommand.format_commands()
+        commands = []
+        for subcommand in subcommands:
+            cmd = group.get_command(click_ctx, subcommand)
+            if cmd is not None:
+                commands.append((subcommand, cmd))
+
+        # allow for 3 times the default spacing
+        if len(commands):
+            limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
+
+            rows = []
+            for subcommand, cmd in commands:
+                help = cmd.get_short_help_str(limit)
+                rows.append((subcommand, help))
+
+            if rows:
+                with formatter.section(section_name):
+                    formatter.write_dl(rows)
 
     def command(self, *args, **kwargs):
         raise DeprecationWarning(
@@ -265,7 +336,33 @@ class Group(click.Group, Task):
             exec = get_current_executor()
             exec.cd(self.cwd)
 
-        return super().invoke(click_ctx)
+        # The code below is directly copied from click.Group.invoke().
+        # The two major differences are: chain mode has been removed and more
+        # importantly, the callback of the current group is called before
+        # resolving the subcommand. In this way, the subcommand filter can use
+        # values dynamically set by the parent callback.
+        def _process_result(value):
+            if self.result_callback is not None:
+                value = ctx.invoke(self.result_callback, value, **ctx.params)
+            return value
+
+        if not click_ctx.protected_args:
+            if self.invoke_without_command:
+                return click.Command.invoke(self, click_ctx)
+            click_ctx.fail('Missing command.')
+
+        # Fetch args back out
+        args = click_ctx.protected_args + click_ctx.args
+        click_ctx.args = []
+        click_ctx.protected_args = []
+        # Make sure the context is entered so we do not clean up
+        # resources until the result processor has worked.
+        with click_ctx:  # type: ignore
+            click.Command.invoke(self, click_ctx)
+            cmd_name, cmd, args = self.resolve_command(click_ctx, args)
+            sub_ctx = cmd.make_context(cmd_name, args, parent=click_ctx)
+            with sub_ctx:  # type: ignore
+                return _process_result(sub_ctx.command.invoke(sub_ctx))
 
     def task(self, *args, **kwargs):
         """This decorator creates a new kitipy task and adds it to the current
@@ -308,41 +405,216 @@ class Group(click.Group, Task):
 
         return decorator
 
-    def stage_group(self, use_default_group=True, **attrs):
+    def stage_group(self, **attrs):
         """This decorator creates a new kitipy.Group and registers it as a
-        stage-scoped group on the current Group.
-        
-        As stage-scoped task groups are regular task groups, this
-        decorator is the only way to create a stage-scoped group.
+        transparent stage-scoped group on all the stacks in this StackGroup.
 
         Args:
-            **attrs: Any options accepted by click.group() decorator.
+            **attrs: Any options accepted by StageGroup constructor.
         """
         def decorator(f):
-            attrs.setdefault('cls', Group)
-            cmd = click.group(**attrs)(_init_stage_group_wrapper(f))
-            self._stage_group = cmd
-            return cmd
+            attrs.setdefault('cls', StageGroup)
+            group = click.group(**attrs)(lambda _: ())
+            self.add_transparent_group(group)
+            return group
 
         return decorator
 
     def stack_group(self, **attrs):
         """This decorator creates a new kitipy.Group and registers it as a
-        stack-scoped group on the current Group.
-        
-        As stack-scoped task groups are regular task groups, this
-        decorator is the only way to create a stack-scope group.
+        transparent stage-scoped group on all the stacks in this StackGroup.
 
         Args:
-            **attrs: Any options accepted by click.group() decorator.
+            **attrs: Any options accepted by StageGroup constructor.
         """
         def decorator(f):
-            attrs.setdefault('cls', Group)
-            cmd = click.group(**attrs)(_init_stack_group_wrapper(f))
-            self._stack_group = cmd
-            return cmd
+            attrs.setdefault('cls', StackGroup)
+            group = click.group(**attrs)(lambda _: ())
+            self.add_transparent_group(group)
+            return group
 
         return decorator
+
+
+class StageGroup(Group):
+    def __init__(self, name: str, **attrs):
+        attrs['filters'] = []
+        super().__init__(name, **attrs)
+        self._stages = {}  # type: Dict[str, Group]
+        self._all = self._create_stage('all')
+
+    @property
+    def all(self):
+        return self._all
+
+    def __getattr__(self, name):
+        if name not in self._stages:
+            self._stages[name] = self._create_stage(name)
+        return self._stages[name]
+
+    def _create_stage(self, stage_name: str, callback=None) -> Group:
+        callback = callback if callback else lambda _: ()
+        callback = _new_stage_callback(stage_name, callback)
+        callback = _prepend_kctx_wrapper(callback)
+        return group(stage_name, cls=Group)(callback)
+
+    def add_command(self, cmd, name=None):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't merge or add new tasks or commands at this point."
+            )
+
+        self._all.add_command(cmd, name)
+
+    def add_transparent_group(self, group: click.MultiCommand):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't add new transparent groups at this point."
+            )
+
+        if group.name in self._transparents:
+            raise KeyError(
+                "There's already a transparent group named %s attached to %s."
+                % (group.name, self.name))
+
+        self._all.add_transparent_group(group)
+
+    def _resolve_commands(self, click_ctx: click.Context):
+        if len(self._resolved) > 0:
+            return self._resolved
+
+        kctx = get_current_context(click_ctx)
+        stages_cfg = kctx.config.get('stages', {})
+        stages = {}
+
+        for name in stages_cfg.keys():
+            if name in self._stages:
+                stages[name] = self._stages[name]
+            else:
+                stages[name] = self._create_stage(name)
+            stages[name].merge(self._all)
+
+        self._resolved = stages  # type: ignore
+        return self._resolved
+
+    def stage(self, name, **attrs):
+        def decorator(f):
+            attrs.setdefault('cls', Group)
+            group = click.group(**attrs)(f)
+            self._stages[name] = group
+            return group
+
+        return decorator
+
+    def list_commands(self, click_ctx: click.Context):
+        return self._resolve_commands(click_ctx).keys()
+
+    def get_command(self, click_ctx: click.Context, cmd_name: str):
+        resolved = self._resolve_commands(click_ctx)
+        return resolved[cmd_name] if cmd_name in resolved else None
+
+    def format_help(self, click_ctx, formatter):
+        raise RuntimeError("StackGroups don't have any specific help message.")
+
+    def invoke(self, click_ctx):
+        raise RuntimeError(
+            "You can't directly invoke a StackGroup, you should instead invoke one of its member."
+        )
+
+    def stage_group(self, **attrs):
+        raise RuntimeError(
+            "You can't add a stage group to another stage group.")
+
+
+class StackGroup(Group):
+    def __init__(self, name, **attrs):
+        attrs['filters'] = []
+        super().__init__(name, **attrs)
+        self._stacks = {}  # type: Dict[str, Group]
+        self._all = self._create_stack('all')
+
+    @property
+    def all(self):
+        return self._all
+
+    def __getattr__(self, name):
+        if name not in self._stacks:
+            self._stacks[name] = self._create_stack(name)
+        return self._stacks[name]
+
+    def _create_stack(self, stack_name: str, callback=None) -> Group:
+        if callback is None:
+            callback = lambda _: ()
+        callback = _new_stack_callback(stack_name, callback)
+        callback = _prepend_kctx_wrapper(callback)
+        return group(stack_name, cls=Group)(callback)
+
+    def add_command(self, cmd, name=None):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't merge or add new tasks or commands at this point."
+            )
+
+        self._all.add_command(cmd, name)
+
+    def add_transparent_group(self, group: click.MultiCommand):
+        if len(self._resolved) > 0:
+            raise RuntimeError(
+                "This task group structure has already been resolved, you can't add new transparent groups at this point."
+            )
+
+        if group.name in self._transparents:
+            raise KeyError(
+                "There's already a transparent group named %s attached to %s."
+                % (group.name, self.name))
+
+        self._all.add_transparent_group(group)
+
+    def _resolve_commands(self, click_ctx: click.Context):
+        if len(self._resolved) > 0:
+            return self._resolved
+
+        kctx = get_current_context(click_ctx)
+        stacks_cfg = kctx.config.get('stacks', {})
+        stacks = {}  # type: Dict[str, Group]
+
+        for name in stacks_cfg.keys():
+            if name in self._stacks:
+                stacks[name] = self._stacks[name]
+            else:
+                stacks[name] = self._create_stack(name)
+            stacks[name].merge(self._all)
+
+        self._resolved = stacks  # type: ignore
+        return self._resolved
+
+    def stack(self, name):
+        def decorator(f):
+            attrs.setdefault('cls', Group)
+            group = click.group(**attrs)(f)
+            self._stacks[name] = group
+            return group
+
+        return decorator
+
+    def list_commands(self, click_ctx: click.Context):
+        return self._resolve_commands(click_ctx).keys()
+
+    def get_command(self, click_ctx: click.Context, cmd_name: str):
+        resolved = self._resolve_commands(click_ctx)
+        return resolved[cmd_name] if cmd_name in resolved else None
+
+    def format_help(self, click_ctx, formatter):
+        raise RuntimeError("StackGroups don't have any specific help message.")
+
+    def invoke(self, click_ctx):
+        raise RuntimeError(
+            "You can't directly invoke a StackGroup, you should instead invoke one of its member."
+        )
+
+    def stack_group(self, **attrs):
+        raise RuntimeError(
+            "You can't add a stack group to another stack group.")
 
 
 def task(name: Optional[str] = None,
@@ -430,41 +702,22 @@ def _prepend_kctx_wrapper(f):
     return wrapper
 
 
-# @TODO: This won't work as expected if the stage-scoped group is declared
-# inside of a stack-scoped group as the stack object has already a copy of the
-# Executor.
-def _init_stage_group_wrapper(f):
-    """This internal function creates a wrapper function run when a
-    stage-scoped group is invoked to change the command Executor set on the
-    kitipy Context.
-
-    Like _prepend_kctx_wrapper(), the wrapper injects kitipy.Context as first
-    argument.
-    """
+def _new_stage_callback(stage_name: str, f):
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        kctx = get_current_context()
-        kctx.with_stage(kctx.meta['stage'])
+    def _stage_callback(kctx: Context, *args, **kwargs):
+        kctx.with_stage(stage_name)
         return f(kctx, *args, **kwargs)
 
-    return wrapper
+    return _stage_callback
 
 
-def _init_stack_group_wrapper(f):
-    """This internal function creates a wrapper function run when a
-    stack-scoped group is invoked to load the requested stack and set it on 
-    current kitipy Context.
-
-    Like _prepend_kctx_wrapper(), the wrapper injects kitipy.Context as first
-    argument.
-    """
+def _new_stack_callback(stack_name: str, f):
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        kctx = get_current_context()
-        kctx.with_stack(kctx.meta['stack'])
+    def _stack_callback(kctx: Context, *args, **kwargs):
+        kctx.with_stack(stack_name)
         return f(kctx, *args, **kwargs)
 
-    return wrapper
+    return _stack_callback
 
 
 class RootCommand(Group):
@@ -514,7 +767,8 @@ class RootCommand(Group):
         if len(stages) == 1:
             stage = list(stages)[0]
         if len(stages) > 1:
-            stage = next((stage for stage in stages if stage['default']), None)
+            stage = next((stage for stage in stages if stage.get('default')),
+                         None)
             if stage is None:
                 raise RuntimeError(
                     'Mutiple stages are defined but none is marked as default.'

--- a/kitipy/utils.py
+++ b/kitipy/utils.py
@@ -5,6 +5,7 @@ import time
 import yaml
 import subprocess
 from typing import Callable, Dict, Optional, TypeVar
+from .exceptions import TaskError
 
 
 def load_config_file(path: str) -> Dict:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -3,7 +3,7 @@ import kitipy
 import pytest
 import subprocess
 from unittest import mock
-from kitipy.context import *
+from kitipy import *
 
 
 def test_get_current_context():

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -6,7 +6,7 @@ import pytest
 import shutil
 import socket
 import tempfile
-from kitipy.executor import InteractiveWarningPolicy
+from kitipy import InteractiveWarningPolicy
 from unittest import mock
 
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,6 +1,7 @@
+import click
 import kitipy
 import pytest
-from kitipy.filters import *
+from kitipy import *
 from unittest import mock
 
 
@@ -13,7 +14,7 @@ def test_local_only():
 
     type(kctx).is_local = mock.PropertyMock(return_value=True)
 
-    assert local_only(click_ctx) == True
+    assert kitipy.filters.local_only(click_ctx) == True
 
 
 def test_local_only_when_no_kitipy_context_available():
@@ -22,7 +23,7 @@ def test_local_only_when_no_kitipy_context_available():
 
     click_ctx.find_object.return_value = None
 
-    assert local_only(click_ctx) == False
+    assert kitipy.filters.local_only(click_ctx) == False
 
 
 def test_remote_only():
@@ -32,7 +33,7 @@ def test_remote_only():
 
     type(kctx).is_remote = mock.PropertyMock(return_value=False)
 
-    assert remote_only(click_ctx) == False
+    assert kitipy.filters.remote_only(click_ctx) == False
 
 
 def test_remote_only_when_no_kitipy_context_available():
@@ -41,4 +42,4 @@ def test_remote_only_when_no_kitipy_context_available():
 
     click_ctx.find_object.return_value = None
 
-    assert remote_only(click_ctx) == False
+    assert kitipy.filters.remote_only(click_ctx) == False

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -1,0 +1,551 @@
+import click
+import kitipy
+import pytest
+from unittest import mock
+
+
+@pytest.fixture
+def executor():
+    return mock.MagicMock(spec=kitipy.Executor)
+
+
+@pytest.fixture
+def kctx(executor):
+    kctx = mock.MagicMock(spec=kitipy.Context)
+    kctx.executor = executor
+    return kctx
+
+
+@pytest.fixture
+def click_ctx(kctx):
+    ctx = mock.MagicMock(spec=click.Context)
+    ctx.params = {}
+    ctx.args = []
+    ctx.protected_args = []
+    ctx.find_object.return_value = kctx
+    return ctx
+
+
+def test_task_is_disabled_when_one_of_its_filter_is_negative(click_ctx):
+    filter = mock.Mock(return_value=False)
+    task = kitipy.Task(name='foobar', filters=[filter])
+
+    assert task.is_enabled(click_ctx) == False
+    filter.assert_called()
+
+
+def test_task_is_disabled_when_it_is_hidden(click_ctx):
+    filter = mock.Mock(return_value=True)
+    task = kitipy.Task(name='foobar', filters=[filter])
+    task.hidden = True
+
+    assert task.is_enabled(click_ctx) == False
+    filter.assert_called()
+
+
+def test_task_is_enabled(click_ctx):
+    filter = mock.Mock(return_value=True)
+    task = kitipy.Task(name='foobar', filters=[filter])
+
+    assert task.is_enabled(click_ctx) == True
+    filter.assert_called()
+
+
+def test_invoke_disabled_task_raises_an_exception(click_ctx):
+    task = kitipy.Task(name='foobar')
+    task.hidden = True
+
+    with pytest.raises(kitipy.TaskError):
+        task.invoke(click_ctx)
+
+
+def test_task_invoke_updates_the_executor_basedir_using_the_task_cwd(
+        click_ctx, executor):
+    with mock.patch('click.get_current_context') as mock_get_current_click_ctx:
+        mock_get_current_click_ctx.return_value = click_ctx
+
+        task = kitipy.Task(name='foobar', cwd='some/base/dir')
+        task.invoke(click_ctx)
+
+        executor.cd.assert_called_with('some/base/dir')
+
+
+def test_task_invoke_calls_the_task_callback():
+    with mock.patch('click.get_current_context') as mock_get_current_click_ctx:
+
+        task = kitipy.Task(name='foobar')
+        task.callback = mock.Mock()
+
+        click_ctx = click.Context(task)
+        mock_get_current_click_ctx.return_value = click_ctx
+
+        task.invoke(click_ctx)
+
+        task.callback.assert_called()
+
+
+def test_group_is_disabled_when_one_of_its_filter_is_negative(click_ctx):
+    filter = mock.Mock(return_value=False)
+    group = kitipy.Group(name='foobar', filters=[filter])
+
+    assert group.is_enabled(click_ctx) == False
+    filter.assert_called()
+
+
+def test_group_is_disabled_when_it_is_hidden(click_ctx):
+    filter = mock.Mock(return_value=True)
+    group = kitipy.Group(name='foobar', filters=[filter])
+    group.hidden = True
+
+    assert group.is_enabled(click_ctx) == False
+    filter.assert_called()
+
+
+def test_group_is_enabled(click_ctx):
+    filter = mock.Mock(return_value=True)
+    group = kitipy.Group(name='foobar', filters=[filter])
+
+    assert group.is_enabled(click_ctx) == True
+    filter.assert_called()
+
+
+def test_invoke_disabled_group_raises_an_exception(click_ctx):
+    group = kitipy.Group(name='foobar')
+    group.hidden = True
+
+    with pytest.raises(kitipy.TaskError):
+        group.invoke(click_ctx)
+
+
+def test_group_invoke_updates_the_executor_basedir_using_the_group_cwd(
+        kctx, executor):
+    with mock.patch('click.get_current_context') as mock_get_current_click_ctx:
+        group = kitipy.Group(name='foobar',
+                             cwd='some/base/dir',
+                             callback=mock.Mock(),
+                             invoke_without_command=True)
+
+        click_ctx = click.Context(group, obj=kctx)
+        mock_get_current_click_ctx.return_value = click_ctx
+
+        group.invoke(click_ctx)
+
+        executor.cd.assert_called_with('some/base/dir')
+        group.callback.assert_called()
+
+
+def test_group_merging_adds_source_commands_and_transparent_groups():
+    src_foo = kitipy.Task(name='foo')
+    src_bar = click.Command(name='bar')
+    src_baz = kitipy.Group(name='baz')
+    src_acme = kitipy.Group(name='acme')
+    src = kitipy.Group(commands={
+        'foo': src_foo,
+        'bar': src_bar,
+        'baz': src_baz,
+    })
+    src.add_transparent_group(src_acme)
+
+    dest_first = kitipy.Task(name='first')
+    dest = kitipy.Group(commands={'first': dest_first})
+    dest.merge(src)
+
+    expected = {
+        'bar': src_bar,
+        'baz': src_baz,
+        'first': dest_first,
+        'foo': src_foo
+    }
+    assert dest.commands == expected
+    assert dest.transparent_groups == [src_acme]
+
+
+def test_group_get_command_looks_for_the_given_command_in_transparent_groups():
+    foo = kitipy.Task(name='foo')
+    acme = kitipy.Group(commands={'foo': foo})
+    root = kitipy.Group()
+    root.add_transparent_group(acme)
+
+    click_ctx = click.Context(root)
+    assert root.get_command(click_ctx, 'foo') == foo
+
+
+def test_group_get_command_cannot_retrieve_transparent_groups_themselves():
+    acme = kitipy.Group(name='acme')
+    root = kitipy.Group()
+    root.add_transparent_group(acme)
+
+    click_ctx = click.Context(root)
+    assert root.get_command(click_ctx, 'acme') is None
+
+
+def test_group_get_command_still_retrieves_usual_commands():
+    foo = kitipy.Task(name='foo')
+    bar = click.Command(name='bar')
+    root = kitipy.Group(commands={'foo': foo, 'bar': bar})
+
+    click_ctx = click.Context(root)
+    assert root.get_command(click_ctx, 'foo') is not None
+    assert root.get_command(click_ctx, 'bar') is not None
+
+
+def test_group_get_command_fails_to_find_disabled_tasks():
+    foo = kitipy.Task(name='foo', filters=[lambda _: False])
+    root = kitipy.Group(commands={'foo': foo})
+
+    click_ctx = click.Context(root)
+    assert root.get_command(click_ctx, 'foo') is None
+
+
+def test_group_get_command_fails_to_find_disabled_tasks_from_transparent_group(
+):
+    foo = kitipy.Task(name='foo', filters=[lambda _: False])
+    acme = kitipy.Group(commands={'foo': foo})
+    root = kitipy.Group(name='root')
+    root.add_transparent_group(acme)
+
+    click_ctx = click.Context(root)
+    assert root.get_command(click_ctx, 'foo') is None
+
+
+def test_group_get_command_raises_an_exception_if_the_name_of_a_command_and_of_a_task_from_a_transparent_group_collides(
+):
+    foo = kitipy.Task(name='foo')
+    acme = kitipy.Group(name='acme', commands={'foo': foo})
+    root = kitipy.Group(commands={'foo': foo})
+    root.add_transparent_group(acme)
+
+    click_ctx = click.Context(root)
+    with pytest.raises(RuntimeError):
+        root.get_command(click_ctx, 'foo')
+
+
+def test_group_get_command_raises_an_exception_if_the_name_of_tasks_from_two_transparent_groups_collides(
+):
+    foo = kitipy.Task(name='foo')
+    acme = kitipy.Group(name='acme', commands={'foo': foo})
+    plop = kitipy.Group(name='plop', commands={'foo': foo})
+
+    root = kitipy.Group()
+    root.add_transparent_group(acme)
+    root.add_transparent_group(plop)
+
+    click_ctx = click.Context(root)
+    with pytest.raises(RuntimeError):
+        root.get_command(click_ctx, 'foo')
+
+
+def test_group_list_commands_looks_for_commands_in_transparent_groups():
+    foo = kitipy.Task(name='foo')
+    bar = kitipy.Task(name='bar')
+    foobar = kitipy.Task(name='foobar', filters=[lambda _: False])
+    acme = kitipy.Group(name='acme', commands={'foo': foo})
+    plop = kitipy.Group(name='plop', commands={'bar': bar, 'foobar': foobar})
+
+    ktp = kitipy.Task(name='ktp')
+    baz = click.Command(name='baz')
+    knp = kitipy.Task(name='knp', filters=[lambda _: False])
+
+    root = kitipy.Group(commands={'ktp': ktp, 'baz': baz, 'knp': knp})
+    root.add_transparent_group(acme)
+    root.add_transparent_group(plop)
+
+    click_ctx = click.Context(root)
+    assert root.list_commands(click_ctx) == ['bar', 'baz', 'foo', 'ktp']
+
+
+def test_group_list_command_raises_an_exception_if_the_name_of_a_command_and_of_a_task_from_a_transparent_group_collides(
+):
+    foo = kitipy.Task(name='foo')
+    acme = kitipy.Group(name='acme', commands={'foo': foo})
+    root = kitipy.Group(commands={'foo': foo})
+    root.add_transparent_group(acme)
+
+    click_ctx = click.Context(root)
+    with pytest.raises(RuntimeError):
+        root.list_commands(click_ctx)
+
+
+def test_group_list_commands_raises_an_exception_if_the_name_of_tasks_from_two_transparent_groups_collides(
+):
+    foo = kitipy.Task(name='foo')
+    acme = kitipy.Group(name='acme', commands={'foo': foo})
+    plop = kitipy.Group(name='plop', commands={'foo': foo})
+
+    root = kitipy.Group()
+    root.add_transparent_group(acme)
+    root.add_transparent_group(plop)
+
+    click_ctx = click.Context(root)
+    with pytest.raises(RuntimeError):
+        root.list_commands(click_ctx)
+
+
+def test_task_decorator_from_group_object_creates_a_new_task_object():
+    root = kitipy.Group(name='root')
+    task = root.task(name='foo', cwd='some/base/dir')(lambda _: ())
+
+    assert root.commands['foo'] == task
+    assert isinstance(task, kitipy.Task)
+    assert task.name == 'foo'
+    assert task.cwd == 'some/base/dir'
+
+
+def test_group_decorator_from_group_object_creates_a_child_group():
+    root = kitipy.Group(name='root')
+    acme = root.group(name='acme', cwd='some/basedir')(lambda _: ())
+
+    assert root.commands['acme'] == acme
+    assert isinstance(acme, kitipy.Group)
+    assert acme.name == 'acme'
+    assert acme.cwd == 'some/basedir'
+
+
+def test_stage_group_decorator_from_group_object_creates_a_child_transparent_group(
+):
+    root = kitipy.Group(name='root')
+    acme = root.stage_group()(lambda: ())
+
+    assert isinstance(acme, kitipy.StageGroup)
+    assert root.transparent_groups == [acme]
+
+
+# def test_stage_group_does_not_accept_cwd():
+#     with pytest.raises(RuntimeError):
+#         kitipy.StageGroup(name='yolo', cwd='yolo')
+
+
+def test_stack_group_decorator_from_group_object_creates_a_child_transparent_group(
+):
+    root = kitipy.Group(name='root')
+    acme = root.stack_group()(lambda: ())
+
+    assert isinstance(acme, kitipy.StackGroup)
+    assert root.transparent_groups == [acme]
+
+
+# def test_stack_group_does_not_accept_cwd():
+#     with pytest.raises(RuntimeError):
+#         kitipy.StackGroup(name='yolo', cwd='yolo')
+
+
+def test_stage_group_automatically_adds_a_stage_if_the_one_accessed_does_not_existt(
+):
+    stages = kitipy.StageGroup(name='stages')
+
+    assert isinstance(stages.dev, kitipy.Group)
+    assert isinstance(stages.prod, kitipy.Group)
+
+
+def test_overriding_groups_parmeters_in_stages_group():
+    stages = kitipy.StageGroup(name='stages')
+    assert len(stages.dev.filters) == 0
+
+    stages.stage('dev', filters=[lambda _: True])(lambda _: ())
+    assert len(stages.dev.filters) == 1
+
+
+def test_stages_group_list_commands_returns_the_intersection_of_configured_stages_and_stages_in_the_group(
+        click_ctx, kctx):
+    stages = kitipy.StageGroup(name='stages')
+    stages.stage('dev')
+    stages.stage('prod')
+    stages.stage('other')
+
+    config = {'stages': {'dev': {}, 'prod': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    assert list(stages.list_commands(click_ctx)) == ['dev', 'prod']
+
+
+def test_stages_group_get_command_returns_nothing_if_the_requested_stage_is_not_in_the_config(
+        click_ctx, kctx):
+    stages = kitipy.StageGroup(name='stages')
+    stages.stage('dev')
+    stages.stage('prod')
+    stages.stage('other')
+
+    config = {'stages': {'dev': {}, 'prod': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    assert stages.get_command(click_ctx, 'other') is None
+
+
+def test_adding_a_task_to_a_whole_stages_group_adds_them_to_all_of_the_subgroups(
+        click_ctx, kctx):
+    stages = kitipy.StageGroup(name='stages')
+    stages.all.task(name='foo')(lambda _: ())
+
+    config = {'stages': {'dev': {}, 'prod': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    dev_group = stages.get_command(click_ctx, 'dev')
+    prod_group = stages.get_command(click_ctx, 'prod')
+
+    assert dev_group.list_commands(click_ctx) == ['foo']
+    assert prod_group.list_commands(click_ctx) == ['foo']
+
+
+def test_adding_a_stacks_group_to_a_whole_stages_group_adds_it_to_all_of_the_stages_subgroups(
+        click_ctx, kctx):
+    stages = kitipy.StageGroup(name='stages')
+    stacks = stages.stack_group(name='stacks')(lambda: ())
+
+    assert isinstance(stacks, kitipy.StackGroup)
+    assert stages.all.transparent_groups == [stacks]
+
+    config = {
+        'stages': {
+            'dev': {},
+            'prod': {}
+        },
+        'stacks': {
+            'api': {},
+            'front': {}
+        }
+    }
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    dev_group = stages.get_command(click_ctx, 'dev')
+    prod_group = stages.get_command(click_ctx, 'prod')
+
+    assert dev_group.list_commands(click_ctx) == ['api', 'front']
+    assert prod_group.list_commands(click_ctx) == ['api', 'front']
+
+
+# def test_set_default_subgroups_params_for_stages_group(click_ctx):
+#     stages = kitipy.StageGroup(name='stages',
+#                                subgroups_params={'stack': 'my-unique-stack'})
+#
+#     assert stages.all.subgroups_params == ['my-unique-stack']
+#
+#     config = {
+#         'stages': {
+#             'dev': {},
+#             'prod': {}
+#         },
+#         'stacks': {
+#             'my-unique-stack': {}
+#         }
+#     }
+#     kctx.config = mock.PropertyMock(wraps=config)
+#
+#     dev_group = stages.get_command(click_ctx, 'dev')
+#     prod_group = stages.get_command(click_ctx, 'prod')
+#
+#     assert dev_group.stack == 'my-unique-stack'
+#     assert prod_group.stack == 'my-unique-stack'
+
+
+def test_adding_a_stages_group_to_another_stages_group_raises_an_exception(
+        click_ctx, kctx):
+    stages = kitipy.StageGroup(name='stages')
+
+    with pytest.raises(RuntimeError):
+        stages.stage_group(name='another')
+
+
+def test_invoking_a_stages_group_is_not_supported(click_ctx):
+    stages = kitipy.StageGroup(name='stages')
+
+    with pytest.raises(RuntimeError):
+        stages.invoke(click_ctx)
+
+
+def test_stacks_group_automatically_adds_a_stack_if_the_one_accessed_does_not_existt(
+):
+    stacks = kitipy.StackGroup(name='stacks')
+
+    assert isinstance(stacks.api, kitipy.Group)
+    assert isinstance(stacks.front, kitipy.Group)
+
+
+def test_overriding_groups_parmeters_in_stacks_group():
+    stacks = kitipy.StackGroup(name='stacks')
+    assert len(stacks.api.filters) == 0
+
+    stacks.stack('api', filters=[lambda _: True])(lambda _: ())
+    assert len(stacks.api.filters) == 1
+
+
+def test_stacks_group_list_commands_returns_the_intersection_of_configured_stacks_and_stacks_in_the_group(
+        click_ctx, kctx):
+    stacks = kitipy.StackGroup(name='stacks')
+    stacks.stack('api')
+    stacks.stack('front')
+    stacks.stack('back')
+
+    config = {'stacks': {'api': {}, 'front': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    assert list(stacks.list_commands(click_ctx)) == ['api', 'front']
+
+
+def test_stacks_group_get_command_returns_nothing_if_the_requested_stack_is_not_in_the_config(
+        click_ctx, kctx):
+    stacks = kitipy.StackGroup(name='stacks')
+    stacks.stack('api')
+    stacks.stack('front')
+    stacks.stack('back')
+
+    config = {'stacks': {'api': {}, 'front': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    assert stacks.get_command(click_ctx, 'other') is None
+
+
+def test_adding_a_task_to_a_whole_stacks_group_adds_them_to_all_of_the_subgroups(
+        click_ctx, kctx):
+    stacks = kitipy.StackGroup(name='stacks')
+    stacks.all.task(name='foo')(lambda _: ())
+
+    config = {'stacks': {'api': {}, 'front': {}}}
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    api_group = stacks.get_command(click_ctx, 'api')
+    front_group = stacks.get_command(click_ctx, 'front')
+
+    assert api_group.list_commands(click_ctx) == ['foo']
+    assert front_group.list_commands(click_ctx) == ['foo']
+
+
+def test_adding_a_stages_group_to_a_whole_stacks_group_adds_it_to_all_of_the_stack_subgroups(
+        click_ctx, kctx):
+    stacks = kitipy.StackGroup(name='stacks')
+    stages = stacks.stage_group(name='stages')(lambda: ())
+
+    assert isinstance(stages, kitipy.StageGroup)
+    assert stacks.all.transparent_groups == [stages]
+
+    config = {
+        'stages': {
+            'dev': {},
+            'prod': {}
+        },
+        'stacks': {
+            'api': {},
+            'front': {}
+        }
+    }
+    kctx.config = mock.PropertyMock(wraps=config)
+
+    api_group = stacks.get_command(click_ctx, 'api')
+    front_group = stacks.get_command(click_ctx, 'front')
+
+    assert api_group.list_commands(click_ctx) == ['dev', 'prod']
+    assert front_group.list_commands(click_ctx) == ['dev', 'prod']
+
+
+def test_adding_a_stack_group_to_another_stack_group_raises_an_exception(
+        click_ctx, kctx):
+    stacks = kitipy.StackGroup(name='stacks')
+
+    with pytest.raises(RuntimeError):
+        stacks.stack_group(name='another')
+
+
+def test_invoking_a_stacks_group_is_not_supported(click_ctx):
+    stacks = kitipy.StackGroup(name='stacks')
+
+    with pytest.raises(RuntimeError):
+        stacks.invoke(click_ctx)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,8 @@
+import kitipy
+import os
 import pytest
 from unittest.mock import Mock
-from kitipy.utils import *
-import kitipy.dispatcher
+from kitipy import *
 
 
 def append_cmd_flags_testdata():


### PR DESCRIPTION
This commit introduces two new objects: StageGroup and StackGroup each
representing a collection of stage/stack-scoped task groups. These
objects gives an easy way to add tasks to all of the groups in the
collection, thus easing the writing of workflows symmetric across
stages/stacks.

As these new objects are click.Group themselves, the concept of
"transparent groups" have been introduced. Any click.Group can be a
"transparent group". To be one, a click.Group have to be added to a
kitipy.Group through `add_transparent_group()` method. When the command
tree is built, kitipy.Groups containing some transparent groups will not
add these groups in the tree, but will instead directly look inside the
groups and attach their subcommands in place of the transparent groups.
As such, transparent groups "locally collapse" the tree by one level.

For instance, consider following code:

```python
foo = kitipy.Task(name='foo')
subgroup = kitipy.Group(name='subgroup', commands={'foo': foo})
group = kitipy.Group(name='group', commands={'subgroup': subgroup})
root = kitipy.RootCommand(commands={'group': group})
```

This will produce the following command tree:

```
root
└── group
    └── subgroup
        └── foo
```

Whereas, with following code:

```python
foo = kitipy.Task(name='foo')
subgroup = kitipy.Group(name='subgroup', commands={'foo': foo})
group = kitipy.Group(name='group', commands={'subgroup': subgroup})
root = kitipy.RootCommand(transparents=[group])
```

Will produce:

```
root
└── subgroup
    └── foo
```