### PR TITLE
Use kitipy Context as a ProxyExecutor

### DIFF
--- a/kitipy/docker/stack.py
+++ b/kitipy/docker/stack.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Union
 
 from .actions import buildx_build, normalize_labels
 from ..context import Context
-from ..executor import Executor
+from ..executor import BaseExecutor
 from ..utils import append_cmd_flags
 
 
@@ -96,7 +96,7 @@ class BaseStack(ABC):
 
 class ComposeStack(BaseStack):
     def __init__(self,
-                 executor: Executor,
+                 executor: BaseExecutor,
                  stack_name='',
                  file='',
                  basedir: str = None):
@@ -285,7 +285,7 @@ class ComposeStack(BaseStack):
 
 class SwarmStack(BaseStack):
     def __init__(self,
-                 executor: Executor,
+                 executor: BaseExecutor,
                  stack_name='',
                  file='',
                  basedir: str = None):
@@ -491,7 +491,7 @@ class SwarmStack(BaseStack):
 
         Args:
             cmd (str): Command to execute
-            **kwargs: Extra arguments passed to Executor.run().
+            **kwargs: Extra arguments passed to BaseExecutor.run().
 
         Raises:
             subprocess.CalledProcessError: When the passed command fail to execute.
@@ -542,7 +542,7 @@ def load_stack(kctx: Context, stack_name: str) -> BaseStack:
 
 
 def _buildx_build_stack(
-        executor: Executor,
+        executor: BaseExecutor,
         stack: BaseStack,
         services: List[str],
         default_context: str,

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -313,7 +313,7 @@ class Group(click.Group):
         resolved = self._resolve_commands(click_ctx).values()
         subcommands = [cmd.name for cmd, group in resolved if group is self]
         self._print_group_help_section(click_ctx, 'Commands', self,
-                                       subcommands, formatter)
+                                       sorted(subcommands), formatter)
 
     def _print_group_help_section(self, click_ctx: click.Context,
                                   section_name: str, group, subcommands,

--- a/tasks.py
+++ b/tasks.py
@@ -31,7 +31,6 @@ def pytest(kctx: kitipy.Context, report_name: Optional[str], coverage: bool,
         basecmd += ' --cov=kitipy/'
 
     kctx.local('%s %s' % (basecmd, cmd), **args)
-    kctx.local('pytest ' + cmd, **args)
 
 
 @kitipy.root(config_file=None, config=config)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -65,9 +65,5 @@ def test_context_run():
 
     kctx.run("some cmd", env={"FOO": "bar"}, pipe=True, check=False)
 
-    executor.run.assert_called_once_with(
-        'some cmd',
-        env={"FOO": "bar"},
-        pipe=True,
-        check=False,
-    )
+    executor.run.assert_called_once_with('some cmd', {"FOO": "bar"}, None, True,
+                                         None, True, None, True, False)


### PR DESCRIPTION
A new Executor ABC named BaseExecutor and a ProxyExecutor which is a
basic executor decorator have been introduced. The kitipy Context now
inherits from the ProxyExecutor, such that the Context can be used as if
it was a real executor.