### PR TITLE
Use contextlib to easily rewind state changes

### DIFF
--- a/kitipy/__init__.py
+++ b/kitipy/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
     'normalize_config',
     'set_up_file_transfer_listeners',
     'wait_for',
-    'confirm_and_apply',
 
     # action modules
     'ansible_actions',

--- a/kitipy/__init__.py
+++ b/kitipy/__init__.py
@@ -3,8 +3,8 @@ from .context import Context, pass_context, get_current_context, get_current_exe
 from .exceptions import TaskError
 from .executor import Executor, InteractiveWarningPolicy
 from .groups import Task, Group, RootCommand, StackGroup, StageGroup, root, task, group
-from .utils import append_cmd_flags, confirm_and_apply, load_config_file, normalize_config, set_up_file_transfer_listeners, wait_for
-from . import filters
+from .utils import append_cmd_flags, confirm_and_apply, invoke_tree, load_config_file, normalize_config, set_up_file_transfer_listeners, wait_for
+from . import docker, filters
 
 from . import ansible_actions, git_actions
 
@@ -36,6 +36,7 @@ __all__ = [
     # from utils module
     'append_cmd_flags',
     'confirm_and_apply',
+    'invoke_tree',
     'load_config_file',
     'normalize_config',
     'set_up_file_transfer_listeners',

--- a/kitipy/utils.py
+++ b/kitipy/utils.py
@@ -5,7 +5,7 @@ import time
 import yaml
 import subprocess
 import sys
-from typing import Callable, Dict, Optional, TypeVar
+from typing import Callable, Dict, List, Optional, TypeVar
 from .exceptions import TaskError
 
 
@@ -276,3 +276,10 @@ def confirm_and_apply(
             sys.exit(exit_code)
 
     apply()
+
+
+def invoke_tree(root: click.Group, subcommands: List[str]):
+    click_ctx = click.get_current_context()
+    click_ctx.args = subcommands[1:]
+    click_ctx.protected_args = subcommands[:1]
+    root.invoke(click_ctx)


### PR DESCRIPTION
Until now, changing the baseir, stage, stack or executor objects would
impact any other code running after that change. This is problematic for
tasks where you need to call a task from another stage/stack-scoped
group. Such case happen for `init-all` tasks where you need to call the
init task of many stacks.

This commit changes the way these values can be set on the kitipy
Context. They're now private properties that can be set through
dedicated `using_*()` methods, which use the contextlib.contextmanager()
decorator and the generator syntax to cleanly commit and rewind state
changes.

Moreover, the Group.invoke() and Task.invoke() methods have been updated
to use their cwd, stage and stack properties to update the kitipy
Context accordingly. This also means that a stage/stack-scoped group can
be created by simply passing the stage/stack name to the group
decorator: `@root.group(stack='mystack')`.