### PR TITLE
Stage/StackGroups now inherits from click.MultiCommand

### DIFF
--- a/kitipy/context.py
+++ b/kitipy/context.py
@@ -4,6 +4,7 @@ import subprocess
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
 from .dispatcher import Dispatcher
+from .exceptions import TaskError
 from .executor import BaseExecutor, ProxyExecutor, _create_executor
 
 
@@ -144,6 +145,11 @@ class Context(ProxyExecutor):
             kwargs[param.name] = default
 
         callback = cmd.callback
+        if callback is None:
+            raise TaskError(
+                'Could not invoke command "%s" as it has no callback attached.'
+                % (cmd.name))
+
         with click.core.augment_usage_errors(parent):
             with ctx:  # type: ignore
                 return callback(*args, **kwargs)  # type: ignore

--- a/kitipy/context.py
+++ b/kitipy/context.py
@@ -109,11 +109,11 @@ class Context(ProxyExecutor):
                 self._stage = previous
 
     @contextmanager
-    def using_stack(self, stack_name):
+    def using_stack(self, stack_name, filename_params: Dict[str, str] = {}):
         from .docker.stack import load_stack
 
         previous = self._stack
-        stack = load_stack(self, stack_name)
+        stack = load_stack(self, stack_name, filename_params)
         stack_cfg = self.config['stacks'][stack_name]
         basedir = stack_cfg.get('basedir')
 

--- a/kitipy/docker/actions.py
+++ b/kitipy/docker/actions.py
@@ -189,6 +189,7 @@ def container_ps(_pipe: bool = False, _check: bool = True,
 
 def container_run(image: str,
                   cmd: str,
+                  rm: bool = True,
                   _pipe: bool = False,
                   _check: bool = True,
                   **kwargs) -> subprocess.CompletedProcess:
@@ -202,6 +203,8 @@ def container_run(image: str,
             Command to run inside the container, with its args.
         **kwargs:
             Take any CLI flag accepted by `docker run`.
+
+            --rm flag is enabled by default.
         _pipe (bool):
             Whether executor pipe mode should be enabled.
         _check (bool):
@@ -216,6 +219,7 @@ def container_run(image: str,
             mode is disabled.
     """
     exec = get_current_executor()
+    kwargs.setdefault('rm', True)
     shcmd = append_cmd_flags('docker container run', **kwargs)
     shcmd += ' %s %s' % (image, cmd)
     return exec.run(shcmd, pipe=_pipe, check=_check)

--- a/kitipy/docker/stack.py
+++ b/kitipy/docker/stack.py
@@ -71,6 +71,10 @@ class BaseStack(ABC):
         pass
 
     @abstractmethod
+    def count_running_services(self) -> int:
+        pass
+
+    @abstractmethod
     def logs(self, services: List[str] = [],
              **kwargs) -> subprocess.CompletedProcess:
         pass
@@ -226,6 +230,9 @@ class ComposeStack(BaseStack):
     def count_services(self, filter: Optional[Dict[str, str]] = None) -> int:
         res = self.ps(filter=filter, _pipe=True, _check=False)
         return len(res.stdout.splitlines())
+
+    def count_running_services(self) -> int:
+        return self.count_sevices(filter=('status=running'))
 
     def logs(self,
              services: List[str] = [],
@@ -440,6 +447,9 @@ class SwarmStack(BaseStack):
         services = self.ps(filter=filter, _pipe=True, _check=False)
         # @TODO: improve it (this is actually buggy)
         return len(services.stdout.splitlines())
+
+    def count_running_services(self) -> int:
+        return self.count_sevices(filter=('status=running'))
 
     def logs(self,
              services: List[str] = [],

--- a/kitipy/docker/stack.py
+++ b/kitipy/docker/stack.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import yaml
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from .actions import buildx_build, normalize_labels
 from ..context import Context
@@ -67,7 +67,7 @@ class BaseStack(ABC):
         pass
 
     @abstractmethod
-    def count_services(self, filter: Optional[Dict[str, str]] = None) -> int:
+    def count_services(self, filter: Optional[Tuple[str]] = None) -> int:
         pass
 
     @abstractmethod
@@ -227,12 +227,12 @@ class ComposeStack(BaseStack):
                         check=_check)
         return res
 
-    def count_services(self, filter: Optional[Dict[str, str]] = None) -> int:
+    def count_services(self, filter: Optional[Tuple[str]] = None) -> int:
         res = self.ps(filter=filter, _pipe=True, _check=False)
         return len(res.stdout.splitlines())
 
     def count_running_services(self) -> int:
-        return self.count_sevices(filter=('status=running'))
+        return self.count_services(filter=('status=running'))  # type: ignore
 
     def logs(self,
              services: List[str] = [],
@@ -443,13 +443,13 @@ class SwarmStack(BaseStack):
                         check=_check)
         return res
 
-    def count_services(self, filter: Optional[Dict[str, str]] = None) -> int:
+    def count_services(self, filter: Optional[Tuple[str]] = None) -> int:
         services = self.ps(filter=filter, _pipe=True, _check=False)
         # @TODO: improve it (this is actually buggy)
         return len(services.stdout.splitlines())
 
     def count_running_services(self) -> int:
-        return self.count_sevices(filter=('status=running'))
+        return self.count_services(filter=('status=running'))  # type: ignore
 
     def logs(self,
              services: List[str] = [],

--- a/kitipy/docker/stack.py
+++ b/kitipy/docker/stack.py
@@ -252,8 +252,7 @@ class ComposeStack(BaseStack):
             _pipe: bool = False,
             _check: bool = True,
             **kwargs) -> subprocess.CompletedProcess:
-        if len(kwargs) == 0:
-            kwargs = {"rm": True}
+        kwargs.setdefault('rm', True)
         run = append_cmd_flags('docker-compose run', **kwargs)
         return self._run('%s %s %s' % (run, service, cmd),
                          pipe=_pipe,
@@ -470,8 +469,7 @@ class SwarmStack(BaseStack):
             _pipe: bool = False,
             _check: bool = True,
             **kwargs) -> subprocess.CompletedProcess:
-        if len(kwargs) == 0:
-            kwargs = {"rm": True}
+        kwargs.setdefault('rm', True)
         run = append_cmd_flags('docker-compose run', **kwargs)
         return self._run('%s %s %s' % (run, service, cmd),
                          pipe=_pipe,

--- a/kitipy/docker/tasks.py
+++ b/kitipy/docker/tasks.py
@@ -37,7 +37,7 @@ def push(kctx: kitipy.Context, tag: str = 'dev', services: List[str] = []):
 @click.argument('services', nargs=-1, type=str)
 @click.option('--tag', type=str, default='dev')
 def up(kctx: kitipy.Context, tag: str = 'dev', services: List[str] = []):
-    kctx.stack.up(services, detach=True)
+    kctx.stack.up(services, detach=True, no_build=True, remove_orphans=True)
 
 
 @docker_tasks.task()

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -308,7 +308,7 @@ class Group(click.Group):
         if self.invoke_on_help:
             self.invoke_without_command = True
             self.invoke(click_ctx)
-        
+
         kctx = get_current_context(click_ctx)
 
         basedir_cm = contextlib.nullcontext()
@@ -322,7 +322,7 @@ class Group(click.Group):
         stack_cm = contextlib.nullcontext()
         if self.stack is not None:
             stack_cm = kctx.using_stack(self.stack)
-        
+
         with basedir_cm, stage_cm, stack_cm:
             return super().get_help(click_ctx)
 
@@ -501,12 +501,17 @@ class Group(click.Group):
         return decorator
 
 
-class StageGroup(Group):
-    def __init__(self, name: str, **attrs):
-        attrs['filters'] = []
+class StageGroup(click.MultiCommand):
+    def __init__(self,
+                 name: str,
+                 subgroups_params: Dict[str, Any] = {},
+                 **attrs):
         super().__init__(name, **attrs)
+        self.subgroups_params = subgroups_params
+
         self._stages = {}  # type: Dict[str, Group]
         self._all = self._create_stage('all')
+        self._resolved = {}  # type: Dict[str, click.Command]
 
     @property
     def all(self):
@@ -522,31 +527,13 @@ class StageGroup(Group):
     def _create_stage(self, stage_name: str, callback=None) -> Group:
         if callback is None:
             callback = lambda _: ()
-
         callback = _prepend_kctx_wrapper(callback)
-        attrs = {'cls': Group, 'stage': stage_name}
-        return group(stage_name, **attrs)(callback)
 
-    def add_command(self, cmd, name=None):
-        if len(self._resolved) > 0:
-            raise RuntimeError(
-                "This task group structure has already been resolved, you can't merge or add new tasks or commands at this point."
-            )
+        args = self.subgroups_params.copy()
+        args['stage'] = stage_name
+        args.setdefault('cls', Group)
 
-        self._all.add_command(cmd, name)
-
-    def add_transparent_group(self, group: click.MultiCommand):
-        if len(self._resolved) > 0:
-            raise RuntimeError(
-                "This task group structure has already been resolved, you can't add new transparent groups at this point."
-            )
-
-        if group.name in self._transparents:
-            raise KeyError(
-                "There's already a transparent group named %s attached to %s."
-                % (group.name, self.name))
-
-        self._all.add_transparent_group(group)
+        return group(stage_name, **args)(callback)
 
     def _resolve_commands(self, click_ctx: click.Context):
         if len(self._resolved) > 0:
@@ -590,17 +577,15 @@ class StageGroup(Group):
             "You can't directly invoke a StackGroup, you should instead invoke one of its member."
         )
 
-    def stage_group(self, **attrs):
-        raise RuntimeError(
-            "You can't add a stage group to another stage group.")
 
-
-class StackGroup(Group):
-    def __init__(self, name, **attrs):
-        attrs['filters'] = []
+class StackGroup(click.MultiCommand):
+    def __init__(self, name, subgroups_params: Dict[str, Any], **attrs):
         super().__init__(name, **attrs)
+        self.subgroups_params = subgroups_params
+
         self._stacks = {}  # type: Dict[str, Group]
         self._all = self._create_stack('all')
+        self._resolved = {}  # type: Dict[str, click.Command]
 
     @property
     def all(self):
@@ -616,31 +601,13 @@ class StackGroup(Group):
     def _create_stack(self, stack_name: str, callback=None) -> Group:
         if callback is None:
             callback = lambda _: ()
-
         callback = _prepend_kctx_wrapper(callback)
-        attrs = {'cls': Group, 'stack': stack_name}
-        return group(stack_name, **attrs)(callback)
 
-    def add_command(self, cmd, name=None):
-        if len(self._resolved) > 0:
-            raise RuntimeError(
-                "This task group structure has already been resolved, you can't merge or add new tasks or commands at this point."
-            )
+        args = self.subgroups_params.copy()
+        args.setdefault('cls', Group)
+        args['stack'] = stack_name
 
-        self._all.add_command(cmd, name)
-
-    def add_transparent_group(self, group: click.MultiCommand):
-        if len(self._resolved) > 0:
-            raise RuntimeError(
-                "This task group structure has already been resolved, you can't add new transparent groups at this point."
-            )
-
-        if group.name in self._transparents:
-            raise KeyError(
-                "There's already a transparent group named %s attached to %s."
-                % (group.name, self.name))
-
-        self._all.add_transparent_group(group)
+        return group(stack_name, **args)(callback)
 
     def _resolve_commands(self, click_ctx: click.Context):
         if len(self._resolved) > 0:
@@ -683,10 +650,6 @@ class StackGroup(Group):
         raise RuntimeError(
             "You can't directly invoke a StackGroup, you should instead invoke one of its member."
         )
-
-    def stack_group(self, **attrs):
-        raise RuntimeError(
-            "You can't add a stack group to another stack group.")
 
 
 def task(name: Optional[str] = None,
@@ -825,6 +788,10 @@ class RootCommand(Group):
         if len(stages) > 1:
             stage = next((stage for stage in stages if stage.get('default')),
                          None)
+            if stage is None:
+                raise RuntimeError(
+                    'Mutiple stages are defined but none is marked as default.'
+                )
             self.stage = stage['name']
 
         stacks = config['stacks'].values()

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -504,10 +504,10 @@ class Group(click.Group):
 class StageGroup(click.MultiCommand):
     def __init__(self,
                  name: str,
-                 subgroups_params: Dict[str, Any] = {},
+                 subgroups_params: Optional[Dict[str, Any]] = None,
                  **attrs):
         super().__init__(name, **attrs)
-        self.subgroups_params = subgroups_params
+        self.subgroups_params = subgroups_params if subgroups_params else {}
 
         self._stages = {}  # type: Dict[str, Group]
         self._all = self._create_stage('all')
@@ -579,9 +579,9 @@ class StageGroup(click.MultiCommand):
 
 
 class StackGroup(click.MultiCommand):
-    def __init__(self, name, subgroups_params: Dict[str, Any], **attrs):
+    def __init__(self, name, subgroups_params: Optional[Dict[str, Any]] = None, **attrs):
         super().__init__(name, **attrs)
-        self.subgroups_params = subgroups_params
+        self.subgroups_params = subgroups_params if subgroups_params else {}
 
         self._stacks = {}  # type: Dict[str, Group]
         self._all = self._create_stack('all')

--- a/tasks.py
+++ b/tasks.py
@@ -92,8 +92,8 @@ def test_unit(kctx: kitipy.Context, report: bool, coverage: bool):
 
     expected_services = len(kctx.stack.config['services'])
     # @TODO: this won't work as is with Swarm, find how to generalize that sort of tests
-    tester = lambda kctx: expected_services == kctx.stack.count_services(
-        filter=('status=running'))
+    tester = lambda kctx: expected_services == kctx.stack.count_running_services(
+    )
     kitipy.wait_for(tester,
                     interval=1,
                     max_checks=5,

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -367,7 +367,7 @@ def test_adding_a_task_to_a_whole_stages_group_adds_them_to_all_of_the_subgroups
 def test_adding_a_stacks_group_to_a_whole_stages_group_adds_it_to_all_of_the_stages_subgroups(
         click_ctx, kctx):
     stages = kitipy.StageGroup(name='stages')
-    stacks = stages.stack_group(name='stacks')(lambda: ())
+    stacks = stages.all.stack_group(name='stacks')(lambda: ())
 
     assert isinstance(stacks, kitipy.StackGroup)
     assert stages.all.transparent_groups == [stacks]
@@ -389,14 +389,6 @@ def test_adding_a_stacks_group_to_a_whole_stages_group_adds_it_to_all_of_the_sta
 
     assert dev_group.list_commands(click_ctx) == ['api', 'front']
     assert prod_group.list_commands(click_ctx) == ['api', 'front']
-
-
-def test_adding_a_stages_group_to_another_stages_group_raises_an_exception(
-        click_ctx, kctx):
-    stages = kitipy.StageGroup(name='stages')
-
-    with pytest.raises(RuntimeError):
-        stages.stage_group(name='another')
 
 
 def test_invoking_a_stages_group_is_not_supported(click_ctx):
@@ -466,7 +458,7 @@ def test_adding_a_task_to_a_whole_stacks_group_adds_them_to_all_of_the_subgroups
 def test_adding_a_stages_group_to_a_whole_stacks_group_adds_it_to_all_of_the_stack_subgroups(
         click_ctx, kctx):
     stacks = kitipy.StackGroup(name='stacks')
-    stages = stacks.stage_group(name='stages')(lambda: ())
+    stages = stacks.all.stage_group(name='stages')(lambda _: ())
 
     assert isinstance(stages, kitipy.StageGroup)
     assert stacks.all.transparent_groups == [stages]
@@ -488,14 +480,6 @@ def test_adding_a_stages_group_to_a_whole_stacks_group_adds_it_to_all_of_the_sta
 
     assert api_group.list_commands(click_ctx) == ['dev', 'prod']
     assert front_group.list_commands(click_ctx) == ['dev', 'prod']
-
-
-def test_adding_a_stack_group_to_another_stack_group_raises_an_exception(
-        click_ctx, kctx):
-    stacks = kitipy.StackGroup(name='stacks')
-
-    with pytest.raises(RuntimeError):
-        stacks.stack_group(name='another')
 
 
 def test_invoking_a_stacks_group_is_not_supported(click_ctx):


### PR DESCRIPTION
This heps avoid collision between stage/stack decorators and the
stage/stack properties previously coming from kitipy.Group parent class.
This also helps remove unneeded methods like add_command() and
add_transparent_group() as such methods don't make sense on groups that
should be used as transparent group only. As such, it forces to use
`@stages.all` or `@stacks.all` syntax to add commands, tasks, groups,
etc...