### PR TITLE
Fix containerDefinitions filtering in ECS run task

### DIFF
--- a/kitipy/tasks/aws/ecs.py
+++ b/kitipy/tasks/aws/ecs.py
@@ -171,7 +171,7 @@ def run(kctx: kitipy.Context, container: str, command: List[str],
     }
 
     task_def["family"] = task_def["family"] + "-oneoff"
-    task_def["containerDefinitions"] = containers
+    task_def["containerDefinitions"] = list(containers)
 
     task_arn = kitipy.libs.aws.ecs.run_oneoff_task(client, cluster_name,
                                                    task_name, task_def,


### PR DESCRIPTION
This was causing following error:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter containerDefinitions, value: <filter object at 0x7f74f47b9430>, type: <class 'filter'>, valid types: <class 'list'>, <class 'tuple'>
```