### PR TITLE
Add image tag field to the ps task for ECS

### DIFF
--- a/kitipy/tasks/aws/ecs.py
+++ b/kitipy/tasks/aws/ecs.py
@@ -220,14 +220,25 @@ def ps(kctx: kitipy.Context,
 
     tasks = kitipy.libs.aws.ecs.list_tasks(client, cluster_name, filters, 10)
     for task in tasks:
-        show_task(kctx, task)
+        task_def = kitipy.libs.aws.ecs.get_task_definition(
+            client, task_def_from_arn(task["taskDefinitionArn"]))
+        image_tag = next((tag["value"]
+                          for tag in task_def["tags"]
+                          if tag["key"] == "kitipy.image_tag"), None)
+        show_task(kctx, task, image_tag)
 
 
-def show_task(kctx: kitipy.Context, task: mypy_boto3_ecs.type_defs.TaskTypeDef):
+def show_task(kctx: kitipy.Context,
+              task: mypy_boto3_ecs.type_defs.TaskTypeDef,
+              image_tag: Optional[str] = None):
     kctx.echo("=================================")
     kctx.echo("Task ID: {0}".format(task_id_from_arn(task["taskArn"])))
     kctx.echo("Task definition: {0}".format(
         task_def_from_arn(task["taskDefinitionArn"])))
+
+    if image_tag:
+        kctx.echo("Image tag: {0}".format(image_tag))
+
     kctx.echo("CPU / Memory: {0} / {1}".format(task["cpu"], task["memory"]))
     kctx.echo("Last status / Desired status: {0} / {1}".format(
         task["lastStatus"], task["desiredStatus"]))


### PR DESCRIPTION
The `ps` command now outputs something like:

```
=================================
Task ID: staging
Task definition: staging-logrouter:109
Image tag: b1a4701cd4f0568f99cb84fa61b09f0796d076a5
CPU / Memory: 256 / 512
Last status / Desired status: RUNNING / RUNNING
Started at: 2020-03-25T12:30:35.706000+01:00
```