### PR TITLE
Use a separate local and remote basedirs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-cache-{{ checksum "Pipfile.lock" }}
+          keys:
+            - v1-deps-cache-{{ checksum "Pipfile" }}
+            - v1-deps-cache
       - run:
           name: Install Python 3.8.1
           command: |
@@ -28,7 +30,7 @@ jobs:
             pip install pipenv
             pipenv install --dev
       - save_cache:
-          key: v1-deps-cache-{{ checksum "Pipfile.lock" }}
+          key: v1-deps-cache-{{ checksum "Pipfile" }}
           paths:
             # pip cache contains pipenv
             - ~/.cache/pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
       CI: true # This makes pipenv less verbose
     steps:
       - checkout
+      - restore_cache:
+          key: v1-deps-cache-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install Python 3.8.1
           command: |
@@ -19,8 +21,6 @@ jobs:
             curl https://pyenv.run | bash
             pyenv install --skip-existing 3.8.1
             pyenv global 3.8.1
-      - restore_cache:
-          key: v1-deps-cache-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install dependencies
           command: |

--- a/kitipy/context.py
+++ b/kitipy/context.py
@@ -34,7 +34,6 @@ class Context(ProxyExecutor):
     handled by RootCommand which can be created through the kitipy.root()
     decorator.
     """
-
     def __init__(self,
                  config: Dict,
                  executor: BaseExecutor,
@@ -110,10 +109,11 @@ class Context(ProxyExecutor):
                 self._stage = previous
 
     @contextmanager
-    def using_stack(self, stack_name, filename_params: Optional[Dict[str, str]] = None):
+    def using_stack(self,
+                    stack_name,
+                    filename_params: Optional[Dict[str, str]] = None):
         from .docker.stack import load_stack
 
-        previous = self._stack
         filename_params = filename_params if filename_params else {}
         stack = load_stack(self, stack_name, filename_params)
         stack_cfg = self.config['stacks'][stack_name]
@@ -123,6 +123,7 @@ class Context(ProxyExecutor):
         if basedir:
             cm = self.cd(basedir)
 
+        previous = self._stack
         with cm:
             try:
                 self._stack = stack

--- a/kitipy/docker/actions.py
+++ b/kitipy/docker/actions.py
@@ -31,6 +31,22 @@ def network_ls(_pipe: bool = False,
     return exec.run(cmd, pipe=_pipe, check=_check)
 
 
+def network_inspect(networks: Union[str, List[str]],
+                    _pipe: bool = False,
+                    _check: bool = True,
+                    **kwargs) -> subprocess.CompletedProcess:
+    exec = get_current_executor()
+    cmd = append_cmd_flags("docker network inspect", **kwargs)
+    networks = [networks] if isinstance(networks, str) else networks
+    return exec.run('%s %s' % (cmd, ' '.join(networks)),
+                    pipe=_pipe,
+                    check=_check)
+
+
+def network_exists(name: str) -> bool:
+    return network_inspect(name, _pipe=True, _check=False).returncode == 0
+
+
 def network_create(name: str,
                    _pipe: bool = False,
                    _check: bool = True,

--- a/kitipy/docker/stack.py
+++ b/kitipy/docker/stack.py
@@ -116,7 +116,7 @@ class ComposeStack(BaseStack):
                  executor: BaseExecutor,
                  stack_name='',
                  file='',
-                 basedir: str = None,
+                 basedir: Optional[str] = None,
                  env: Optional[Dict[str, str]] = None):
         self._name = stack_name
         self._executor = executor
@@ -585,9 +585,7 @@ def load_stack(kctx: Context,
         raise click.BadParameter('Stack %s not defined in the config.' %
                                  (stack_name))
 
-    stack_basedir = stack_config.get('basedir', None)
-    if stack_basedir is None:
-        stack_basedir = os.getcwd()
+    stack_basedir = stack_config.get('basedir')
 
     # @TODO: add templated stack filename
     # stack_file = stack_config.get('file', '%s.yml' % (stage))

--- a/kitipy/executor.py
+++ b/kitipy/executor.py
@@ -94,6 +94,10 @@ class BaseExecutor(ABC):
     def remote_cwd(self) -> Optional[str]:
         pass
 
+    @abstractmethod
+    def mkdir(self, path: str):
+        pass
+
 
 class Executor(BaseExecutor):
     """Executor provides a common abstraction to execute commands and
@@ -703,6 +707,13 @@ class Executor(BaseExecutor):
     def remote_cwd(self) -> Optional[str]:
         return self._remote_basedir
 
+    def mkdir(self, path: str):
+        if not os.path.isabs(path):
+            path = self._join_paths(self._remote_basedir, path)
+
+        res = self._remote("mkdir -p %s" % (path))
+        return res.stdout
+
 
 def _create_executor(config: Dict, stage_name: str,
                      dispatcher: Dispatcher) -> Executor:
@@ -810,6 +821,9 @@ class ProxyExecutor(BaseExecutor):
                 prefix: Optional[str] = None,
                 dir: Optional[str] = None) -> str:
         return self._executor.mkdtemp(suffix, prefix, dir)
+
+    def mkdir(self, path: str):
+        self._executor.mkdir(path)
 
     def cd(self, path: str):
         return self._executor.cd(path)

--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -24,11 +24,12 @@ class Task(click.Command):
     kitipy provides some filters in kitipy.filters and kitipy.docker.filters
     but you can also write your own filters if you have more advanced use-cases.
     """
-    def __init__(self,
-                 name: str,
-                 filters: Optional[List[Callable[[click.Context], bool]]] = None,
-                 cwd: Optional[str] = None,
-                 **kwargs):
+    def __init__(
+            self,
+            name: str,
+            filters: Optional[List[Callable[[click.Context], bool]]] = None,
+            cwd: Optional[str] = None,
+            **kwargs):
         """
         Args:
             name (str):
@@ -98,17 +99,18 @@ class Group(click.Group):
     features like: support for stage/stack-scoped task groups and task
     filtering.
     """
-    def __init__(self,
-                 name=None,
-                 commands=None,
-                 tasks: Optional[List[Task]] = None,
-                 stage: Optional[str] = None,
-                 stack: Optional[str] = None,
-                 filters: Optional[List[Callable[[click.Context], bool]]] = None,
-                 cwd: Optional[str] = None,
-                 invoke_on_help: bool = False,
-                 transparents: List[click.MultiCommand] = [],
-                 **attrs):
+    def __init__(
+            self,
+            name=None,
+            commands=None,
+            tasks: Optional[List[Task]] = None,
+            stage: Optional[str] = None,
+            stack: Optional[str] = None,
+            filters: Optional[List[Callable[[click.Context], bool]]] = None,
+            cwd: Optional[str] = None,
+            invoke_on_help: bool = False,
+            transparents: List[click.MultiCommand] = [],
+            **attrs):
         """
         Args:
             name (str):
@@ -235,6 +237,7 @@ class Group(click.Group):
             else:
                 sub_names, sub_origs, sub_cmds = ((), (), ())
 
+            # @TODO: check if the subcommand
             colliding = list(set(origins.keys()) & set(sub_names))
             if len(colliding) > 0:
                 error = ', '.join([
@@ -519,7 +522,8 @@ class StageGroup(click.MultiCommand):
 
     def __getattr__(self, name):
         if name.startswith('_'):
-            raise AttributeError("Stage group names can't start with an underscore.")
+            raise AttributeError(
+                "Stage group names can't start with an underscore.")
         if name not in self._stages:
             self._stages[name] = self._create_stage(name)
         return self._stages[name]
@@ -579,7 +583,10 @@ class StageGroup(click.MultiCommand):
 
 
 class StackGroup(click.MultiCommand):
-    def __init__(self, name, subgroups_params: Optional[Dict[str, Any]] = None, **attrs):
+    def __init__(self,
+                 name,
+                 subgroups_params: Optional[Dict[str, Any]] = None,
+                 **attrs):
         super().__init__(name, **attrs)
         self.subgroups_params = subgroups_params if subgroups_params else {}
 
@@ -593,7 +600,8 @@ class StackGroup(click.MultiCommand):
 
     def __getattr__(self, name):
         if name.startswith('_'):
-            raise AttributeError("Stack group names can't start with an underscore.")
+            raise AttributeError(
+                "Stack group names can't start with an underscore.")
         if name not in self._stacks:
             self._stacks[name] = self._create_stack(name)
         return self._stacks[name]
@@ -823,7 +831,7 @@ class RootCommand(Group):
                                        info_name=info_name,
                                        parent=parent,
                                        **extra)
-        executor = Executor(os.getcwd(), self._dispatcher)
+        executor = Executor(self._dispatcher)
         self.click_ctx.obj = Context(self._config, executor, self._dispatcher)
 
         with self.click_ctx.scope(cleanup=False):

--- a/tests/tasks/test_git.py
+++ b/tests/tasks/test_git.py
@@ -24,7 +24,7 @@ def executor(dispatcher: kitipy.Dispatcher) -> kitipy.Executor:
     subprocess.run('tar -C %s -zxf %s' % (baredir, tgz_path), shell=True)
     subprocess.run('git clone %s %s' % (baredir, clonedir), shell=True)
 
-    yield kitipy.Executor(clonedir, dispatcher)
+    yield kitipy.Executor(dispatcher, local_basedir=clonedir)
 
     shutil.rmtree(baredir)
     shutil.rmtree(clonedir)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -20,7 +20,7 @@ def executor(request):
 
     if request.param == "local":
         basedir = tempfile.mkdtemp()
-        yield kitipy.Executor(basedir, dispatcher)
+        yield kitipy.Executor(dispatcher, local_basedir=basedir)
         shutil.rmtree(basedir)
         return
 
@@ -28,8 +28,8 @@ def executor(request):
     if request.param == "remote_with_jumphost":
         hostname = 'testhost-via-jumphost'
 
-    executor = kitipy.Executor(str(pathlib.Path.home()),
-                               dispatcher,
+    executor = kitipy.Executor(dispatcher,
+                               local_basedir=str(pathlib.Path.home()),
                                hostname=hostname,
                                ssh_config_file=ssh_config_file,
                                paramiko_config={


### PR DESCRIPTION
This is useful for executing local commands whereas the Executor has
been configured to run in remote mode. Until now, as there was a single
parameter to set the basedir, it was used when trying to execute
commands through `Executor.local()`.