### PR TITLE
Create Dispatcher and call set_up_file_transfer_listeners in two steps

### DIFF
--- a/kitipy/groups.py
+++ b/kitipy/groups.py
@@ -788,9 +788,10 @@ class RootCommand(Group):
         kwargs['filters'] = []
         super().__init__(**kwargs)
 
-        self._config = normalize_config(config)
-        self._dispatcher = set_up_file_transfer_listeners(Dispatcher())
         self.click_ctx = None
+        self._config = normalize_config(config)
+        self._dispatcher = Dispatcher()
+        set_up_file_transfer_listeners(self._dispatcher)
 
         stages = config['stages'].values()
         if len(stages) == 1:


### PR DESCRIPTION
set_up_file_transfer_listeners was called at the same line where the
Dispatcher was created. Howsever, this function returns nothing, thus
the executor was later failing to call any dispatcher method.